### PR TITLE
Won't fail if `addresses_to_search` isn't iterable

### DIFF
--- a/docassemble/ALMassachusetts/data/questions/al_massachusetts.yml
+++ b/docassemble/ALMassachusetts/data/questions/al_massachusetts.yml
@@ -1,6 +1,7 @@
 ---
 modules:
   - docassemble.MACourts.macourts
+  - collections.abc
 ---
 objects:
   - trial_court: MACourt
@@ -151,7 +152,12 @@ subquestion: |
 
   % if len(all_matches) > 0:
   Below is a map of the court(s) that serve
-  the address you gave us, ${comma_and_list([address.on_one_line() for address in addresses_to_search],comma_string='; ')}.
+  the address you gave us, 
+  % if isinstance(addresses_to_search, Iterable):
+  ${comma_and_list([address.on_one_line() for address in addresses_to_search],comma_string='; ')}.
+  % else:
+  ${addresses_to_search.on_one_line()}
+  % endif
   
   ${map_of(combined_locations(all_matches))}
   % endif


### PR DESCRIPTION
This came up in Teaching Tuesday: Aubrey wanted to override `addresses_to_search` to not ask for the addresses from other people on the same side in the case, and tried `addresses_to_search = users[0].address`, which seemed like it could have worked, except it errored.

Given that the other place `addresses_to_search` is [matching_courts()](https://github.com/GBLS/docassemble-MACourts/blob/6035393a09cff3e8a371f19b79d1cde3a60691c1/docassemble/MACourts/macourts.py#L326), which does handle both iterables and non-iterables, it makes sense that we handle non-iterables when displaying things too.