### PR TITLE
Correct address bug in ALMassachusetts and AL ql

### DIFF
--- a/docassemble/ALMassachusetts/data/questions/al_massachusetts.yml
+++ b/docassemble/ALMassachusetts/data/questions/al_massachusetts.yml
@@ -47,6 +47,10 @@ code: |
   # This is a placeholder for the addresses that will be searched
   # for matching address to court
   # TODO: is there a better default? Probably very case specific
+
+  # before adding all of the addresses to search, ensure they are
+  # defined. Otherwise, can get into an infinite loop
+  [user.address.address for user in users]
   addresses_to_search = [user.address for user in users]
 ---
 comment: |


### PR DESCRIPTION
If you have more than one `users`, and you trigger `addresses_to_search` before
you complete the addresses of each user, you can get stuck in an infinite loop.
The second user (`users[1]`) will have the option to reuse `users[0]`'s
address, which changes the object that `users[1].address` points to. However,
`addresses_to_search` still holds the older object, and thus can't be set
properly, so DA will ask the same question in a loop.

The fix is to explicitly trigger the `address.address` before adding the
objects to `addresses_to_search`. In most cases, `addresses_to_search` is only
triggered right before the `address.address` values are used, so it shouldn't
change the order of any questions.

Here's a small snippet to reproduce the issue before this patch and prove it's been fixed after the patch:

```yml
---
include:
  - docassemble.AssemblyLine:assembly_line.yml
  - docassemble.ALMassachusetts:al_massachusetts.yml
---
mandatory: True
code: |
  users.gather()
  addresses_to_search
  addresses_to_search[1].city
```